### PR TITLE
compilation without warnings on Ubuntu

### DIFF
--- a/src/http.c
+++ b/src/http.c
@@ -9,7 +9,7 @@
 
 void http_static_response(request_t *req, config_StaticResponse_t *resp) {
     char status[resp->status_len + 5];
-    sprintf(status, "%03d %s", resp->code, resp->status);
+    sprintf(status, "%03ld %s", resp->code, resp->status);
     SNIMPL(ws_statusline(&req->ws, status));
     //ws_add_header(&req->ws, "Server", config.Server.header);
     CONFIG_STRING_STRING_LOOP(line, resp->headers) {

--- a/src/log.c
+++ b/src/log.c
@@ -98,7 +98,7 @@ void timedwarn(time_t *tt, char *file, int line, char *msg, ...) {
         idx += vsnprintf(buf + idx, 4096 - idx, msg, args);
         idx = min(idx, 4094);
         if(tt[WT_LASTCALL] > tm - logconfig->warning_timeout) {
-            idx += snprintf(buf + idx, 4096 - idx, " (repeated %d times)", tt[WT_COUNTER]);
+            idx += snprintf(buf + idx, 4096 - idx, " (repeated %ld times)", tt[WT_COUNTER]);
         }
         buf[idx++] = '\n';
         write(logfile, buf, idx);

--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,7 @@ int format_statistics(char *buf) {
     struct timeval tv;
     gettimeofday(&tv, NULL);
     int res = snprintf(buf, STAT_MAXLEN,
-        "%lu.%06d\n"
+        "%lu.%06ld\n"
         "connects: %lu\n"
         "disconnects: %lu\n"
         "http_requests: %lu\n"

--- a/src/polling.c
+++ b/src/polling.c
@@ -337,7 +337,7 @@ static void send_later(struct ev_loop *loop, struct ev_idle *watch, int rev) {
         if(comet->cur_format == FMT_SINGLE) {
             root.stat.comet_sent_messages += 1;
             char buf[24];
-            sprintf(buf, "%lu", comet->first_index);
+            sprintf(buf, "%i", comet->first_index);
             ws_statusline(req, "200 OK");
             ws_add_header(req, "X-Messages", "1");
             ws_add_header(req, "X-Format", "single");
@@ -358,9 +358,9 @@ static void send_later(struct ev_loop *loop, struct ev_idle *watch, int rev) {
             }
             char buf[128];
             ws_statusline(req, "200 OK");
-            sprintf(buf, "%lu", num);
+            sprintf(buf, "%i", num);
             ws_add_header(req, "X-Messages", buf);
-            sprintf(buf, "%lu", comet->first_index + comet->queue.size);
+            sprintf(buf, "%i", comet->first_index + comet->queue.size);
             ws_add_header(req, "X-Last-ID", buf);
             ws_add_header(req, "X-Format", "multipart");
             sprintf(buf, "multipart/mixed; boundary=\"%s\"", boundary);
@@ -381,7 +381,7 @@ static void send_later(struct ev_loop *loop, struct ev_idle *watch, int rev) {
                         "X-Message-ID: ",
                     strlen("\r\nContent-Type: application/octed-stream\r\n"
                         "X-Message-ID "));
-                int len = sprintf(buf, "%lu", comet->first_index + i);
+                int len = sprintf(buf, "%i", comet->first_index + i);
                 obstack_grow(&req->pieces, buf, len);
                 obstack_grow(&req->pieces, "\r\n\r\n", 4);
                 obstack_grow(&req->pieces, zmq_msg_data(&msg->zmsg),


### PR DESCRIPTION
I removed all printf's pattern mismatches. Not zerogw is compiled cleanly.
